### PR TITLE
Bootstrap 5 update

### DIFF
--- a/stylesheet.css
+++ b/stylesheet.css
@@ -3,6 +3,7 @@
  *   */
 .concept-widget {
     border-top: 2px solid #394554;
+    margin-bottom: 20px;
 }
 
 .concept-widget > .panel, .concept-widget #map {

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -56,7 +56,8 @@
 }
 
 #headingMap .map-caption-vocabulary {
-    float: right;
+    position: absolute;
+    right: 45px;
     color: gray;
 }
 

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -58,3 +58,13 @@
     float: right;
     color: gray;
 }
+
+#headingMap .accordion-button {
+    color: var(--medium-color);
+    background-color: var(--white);
+    padding-top: 0.2rem;
+    padding-right: 1rem;
+    padding-bottom: 0.2rem;
+    padding-left: 1rem;
+    font-size: 14px;
+}

--- a/stylesheet.css
+++ b/stylesheet.css
@@ -64,9 +64,9 @@
 #headingMap .accordion-button {
     color: var(--medium-color);
     background-color: var(--white);
-    padding-top: 0.2rem;
+    padding-top: 0.5rem;
     padding-right: 1rem;
-    padding-bottom: 0.2rem;
+    padding-bottom: 0.5rem;
     padding-left: 1rem;
-    font-size: 14px;
+    font-size: 1rem;
 }

--- a/template.html
+++ b/template.html
@@ -1,12 +1,12 @@
 <div class="concept-widget panel-group" id="mapAccordion" role="tablist" aria-multiselectable="true">
     <div class="panel panel-default">
         <div class="panel-heading" role="tab" id="headingMap">
-            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMap" aria-expanded="true" aria-controls="collapseMap">
+            <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMap" aria-expanded="true" aria-controls="collapseMap">
                 {{mapCaption}}
             </button>
             <span class="map-caption-vocabulary versal">{{mapVocabulary}}</span>
         </div>
-        <div id="collapseMap" class="panel-collapse collapse{{#if opened}} in{{/if}}" role="tabpanel" aria-labelledby="headingMap">
+        <div id="collapseMap" class="panel-collapse collapse show" role="tabpanel" aria-labelledby="headingMap">
             <div class="panel-body">
                 <div id="map" class="panel" role="tabpanel" aria-labelledby="headingMapWidget"></div>
             </div>

--- a/template.html
+++ b/template.html
@@ -1,11 +1,9 @@
 <div class="concept-widget panel-group" id="mapAccordion" role="tablist" aria-multiselectable="true">
     <div class="panel panel-default">
         <div class="panel-heading" role="tab" id="headingMap">
-            <a class="collapsed" role="button" data-toggle="collapse" data-parent="#mapAccordion" href="#collapseMap" aria-expanded="false" aria-controls="collapseMap">
-                <span class="glyphicon glyphicon-chevron-{{#if opened}}up{{else}}down{{/if}}" aria-hidden="true"></span></a>
-            <a class="collapsed versal" role="button" data-toggle="collapse" data-parent="#mapAccordion" href="#collapseMap" aria-expanded="false" aria-controls="collapseMap">
+            <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMap" aria-expanded="true" aria-controls="collapseMap">
                 {{mapCaption}}
-            </a>
+            </button>
             <span class="map-caption-vocabulary versal">{{mapVocabulary}}</span>
         </div>
         <div id="collapseMap" class="panel-collapse collapse{{#if opened}} in{{/if}}" role="tabpanel" aria-labelledby="headingMap">

--- a/template.html
+++ b/template.html
@@ -3,8 +3,8 @@
         <div class="panel-heading" role="tab" id="headingMap">
             <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMap" aria-expanded="true" aria-controls="collapseMap">
                 {{mapCaption}}
+                <span class="map-caption-vocabulary float-end versal">{{mapVocabulary}}</span>
             </button>
-            <span class="map-caption-vocabulary versal">{{mapVocabulary}}</span>
         </div>
         <div id="collapseMap" class="panel-collapse collapse show" role="tabpanel" aria-labelledby="headingMap">
             <div class="panel-body">

--- a/template.html
+++ b/template.html
@@ -8,7 +8,7 @@
         </div>
         <div id="collapseMap" class="panel-collapse collapse show" role="tabpanel" aria-labelledby="headingMap">
             <div class="panel-body">
-                <div id="map" class="panel" role="tabpanel" aria-labelledby="headingMapWidget"></div>
+                <div id="map" class="panel position-sticky" role="tabpanel" aria-labelledby="headingMapWidget"></div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Reasons for creating this PR

Bootstrap 5 Upgrade broke the layout for several Skosmos widgets, requiring an overhaul to UI elements.

## Description of the changes in this PR

 - Fixed the collapsing element for the widget
 - Fixed the placement of source vocabulary text

## Known problems or uncertainties in this PR

 - None
